### PR TITLE
Use print_r instead of var_dump

### DIFF
--- a/math.php
+++ b/math.php
@@ -7,6 +7,6 @@ $A = array(array(2, 4), array(1, 1));
 $x = array(8, 2);
 $gaus = new Gaussian();
 
-var_dump($gaus->solve($A, $x));
+print_r($gaus->solve($A, $x));
 
 


### PR DESCRIPTION
Floating point numbers in PHP are inaccurate (http://php.net/manual/de/language.types.float.php) thus this code:
```php
$A = array(
    array(9, 3, 4),
    array(4, 3, 4),
    array(1, 1, 1)
);
$x = array(7, 8, 3);
$gaus = new Gaussian();

var_dump($gaus->solve($A, $x));
```
is gonna display:
```
array(3) { [0]=> float(-0.19999999999999987) [1]=> float(3.9999999999999996) [2]=> float(-0.7999999999999997) }
```

Whereas
```php
print_r($gaus->solve($A, $x));
```
prints out:
```
Array ( [0] => -0.2 [1] => 4 [2] => -0.8 )
```